### PR TITLE
Dockerfile for website image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Use the official Nginx image as the base image
+FROM nginx:alpine
+
+# Set the working directory inside the container
+WORKDIR /usr/share/nginx/html
+
+# Copy the current directory contents (HTML, CSS, JS) into the container
+COPY . .
+
+# Expose port 80 to the host
+EXPOSE 80
+
+# The default Nginx configuration serves files from /usr/share/nginx/html
+# No CMD instruction is needed as the Nginx base image already specifies the default command


### PR DESCRIPTION
this is a working dockerfile that uses nginx base image as the webserver that will serve our static website files on the browser. it lives within the app directory and copies the app files into the container. it ignores the RUN command because by default when the container starts nginx performs the operations of starting and serving the webfiles on default.